### PR TITLE
Update mailsync to have it look in "inbox" and "Inbox"

### DIFF
--- a/etc/mailsync.sh
+++ b/etc/mailsync.sh
@@ -31,7 +31,7 @@ pkill -RTMIN+12 i3blocks
 for account in $(ls ~/.mail)
 do
 	#List unread messages newer than last mailsync and count them
-	newcount=$(find ~/.mail/"$account"/INBOX/new/ -type f -newer ~/.config/mutt/etc/.mailsynclastrun 2> /dev/null | wc -l)
+	newcount=$(find ~/.mail/"$account"/INBOX/new/ ~/.mail/"$account"/inbox/new/ ~/.mail/"$account"/Inbox/new/ -type f -newer ~/.config/mutt/etc/.mailsynclastrun 2> /dev/null | wc -l)
 	if [ "$newcount" -gt "0" ]
 	then
 		notify "$account" "$newcount" &


### PR DESCRIPTION
Several email providers name their inbox folder with a wide usage of lowercase or uppercase letters (INBOX, inbox, Inbox). This commit makes mailsync.sh looks in different folders so that the notification works properly whenever there is a new email in INBOX, Inbox or inbox